### PR TITLE
support production mode in graphql-server

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -42,6 +42,7 @@ services:
       - -c
       - |
         npm install
+        chmod u+x ./migrateDbAndStartServer-prod.sh
         ./migrateDbAndStartServer-prod.sh
 
   zendro_spa:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -42,7 +42,7 @@ services:
       - -c
       - |
         npm install
-        ./migrateDbAndStartServer.sh
+        ./migrateDbAndStartServer-prod.sh
 
   zendro_spa:
     container_name: zendroStarterPack_spa


### PR DESCRIPTION
To support the production mode in graphql-server, it is necessary to update the docker-compose file in the starterPack.