### PR TITLE
Revision: docker setup

### DIFF
--- a/2021-12-08T17_37_17.804Z#keycloak.js
+++ b/2021-12-08T17_37_17.804Z#keycloak.js
@@ -13,10 +13,10 @@ const GIQL_PRD_ENV = require("dotenv").config({
   path: path.resolve(__dirname, "../../graphiql-auth/.env.production"),
 });
 const SPA_DEV_ENV = require("dotenv").config({
-  path: path.resolve(__dirname, "../../single-page-app/.env.production"),
+  path: path.resolve(__dirname, "../../single-page-app/.env.development"),
 });
 const GIQL_DEV_ENV = require("dotenv").config({
-  path: path.resolve(__dirname, "../../graphiql-auth/.env.production"),
+  path: path.resolve(__dirname, "../../graphiql-auth/.env.development"),
 });
 
 const {

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -61,6 +61,8 @@ services:
     networks:
       zendro:
       datastores:
+    # workaround "sed" command to enable a development / production-Sandbox mode in a local environment
+    # can be removed in a production deployment
     command:
       - /bin/sh
       - -c
@@ -93,8 +95,8 @@ services:
     # Workaround for local development and Sandbox setups. Can be remove in production deployment
     extra_hosts:
       - "localhost:host-gateway"
-    # Install dependencies and start single-page-app-server in development
-    # mode.
+    # workaround "sed" command to enable a development / production-Sandbox mode in a local environment
+    # can be removed in a production deployment
     command:
       - /bin/sh
       - -c
@@ -128,6 +130,8 @@ services:
     # Workaround for local development and Sandbox setups. Can be remove in production deployment
     extra_hosts:
       - "localhost:host-gateway"
+    # workaround "sed" command to enable a development / production-Sandbox mode in a local environment
+    # can be removed in a production deployment
     command:
       - /bin/sh
       - -c

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -17,9 +17,8 @@ services:
   zendro_keycloak:
     container_name: zendro_keycloak
     image: quay.io/keycloak/keycloak:15.0.2
-    command: ["-Djboss.http.port=8081"]
     ports:
-      - 8081:8081
+      - 8081:8080
     environment:
       DB_VENDOR: POSTGRES
       DB_ADDR: zendro_keycloak_postgres
@@ -33,7 +32,6 @@ services:
       - zendro_keycloak_postgres
     networks:
       zendro:
-        ipv4_address: 10.5.0.11
 
   zendro_graphql_server:
     container_name: zendroStarterPack_graphql-server
@@ -67,6 +65,7 @@ services:
       - /bin/sh
       - -c
       - |
+        sed -e '/127.0.0.1\tlocalhost/d' -e 's/^::1\tlocalhost/::1\t/' /etc/hosts > /etc/hosts2 && cp /etc/hosts2 /etc/hosts && rm /etc/hosts2
         npm install
         chmod u+x ./migrateDbAndStartServer.sh
         ./migrateDbAndStartServer.sh dev
@@ -89,17 +88,21 @@ services:
     volumes:
       - ./single-page-app:/usr/single-page-app
       - ./data_model_definitions:/usr/data_model_definitions
+    networks:
+      zendro:
+    # Workaround for local development and Sandbox setups. Can be remove in production deployment
+    extra_hosts:
+      - "localhost:host-gateway"
     # Install dependencies and start single-page-app-server in development
     # mode.
     command:
       - /bin/sh
       - -c
       - |
+        sed -e '/127.0.0.1\tlocalhost/d' -e 's/^::1\tlocalhost/::1\t/' /etc/hosts > /etc/hosts2 && cp /etc/hosts2 /etc/hosts && rm /etc/hosts2
         rm -rf .next
         yarn install
         yarn dev
-    networks:
-      zendro:
 
   zendro_graphiql:
     container_name: zendroStarterPack_graphiql-auth
@@ -122,11 +125,16 @@ services:
     # mode.
     networks:
       zendro:
+    # Workaround for local development and Sandbox setups. Can be remove in production deployment
+    extra_hosts:
+      - "localhost:host-gateway"
     command:
       - /bin/sh
       - -c
       - |
+        sed -e '/127.0.0.1\tlocalhost/d' -e 's/^::1\tlocalhost/::1\t/' /etc/hosts > /etc/hosts2 && cp /etc/hosts2 /etc/hosts && rm /etc/hosts2
         rm -rf .next
+        yarn install
         yarn dev
         
 volumes:
@@ -135,8 +143,4 @@ volumes:
 
 networks:
   zendro:
-    driver: bridge
-    ipam:
-      config:
-        - subnet: 10.5.0.0/24
   datastores:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -77,8 +77,11 @@ services:
       - traefik.http.routers.zendro_graphql_server.rule=Host(`localhost`) && PathPrefix(`/api/`)
       - traefik.http.routers.zendro_graphql_server.middlewares=strip-api@docker
       - traefik.http.middlewares.strip-api.stripprefix.prefixes=/api/
+    # Workaround for local development and Sandbox setups. Can be remove in production deployment
     extra_hosts:
       - "localhost:host-gateway"
+    # workaround "sed" command to enable a development / production-Sandbox mode in a local environment
+    # can be removed in a production deployment
     command:
       - /bin/sh
       - -c

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -2,6 +2,21 @@ version: "3.7"
 
 services:
 
+  reverse_proxy:
+    # The official v2 Traefik docker image
+    image: traefik:latest
+    # Enables the web UI and tells Traefik to listen to docker
+    command: --providers.docker
+    ports:
+      # The HTTP port
+      - 80:80
+    volumes:
+      # So that Traefik can listen to the Docker events
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      zendro:
+      datastores:
+
   zendro_keycloak_postgres:
     container_name: pgdb_keycloak
     image: postgres
@@ -17,9 +32,6 @@ services:
   zendro_keycloak:
     container_name: zendro_keycloak
     image: quay.io/keycloak/keycloak:15.0.2
-    command: ["-Djboss.http.port=8081"]
-    ports:
-      - 8081:8081
     environment:
       DB_VENDOR: POSTGRES
       DB_ADDR: zendro_keycloak_postgres
@@ -33,7 +45,8 @@ services:
       - zendro_keycloak_postgres
     networks:
       zendro:
-        ipv4_address: 10.5.0.11
+    labels:
+      - traefik.http.routers.zendro_keycloak.rule=Host(`localhost`)
 
   zendro_graphql_server:
     container_name: zendroStarterPack_graphql-server
@@ -47,9 +60,6 @@ services:
       JQ_PATH: /usr/bin/jq
       NODE_JQ_SKIP_INSTALL_BINARY: "true"
       REQUIRE_SIGN_IN: "true"
-    # Using ports in this way is a security concern. Please consider using e.g. a reverseproxy
-    ports:
-      - 3000:3000
     volumes:
       - ./graphql-server:/usr/graphql-server
       # override default default config with Starterpack config
@@ -63,10 +73,17 @@ services:
     networks:
       zendro:
       datastores:
+    labels:
+      - traefik.http.routers.zendro_graphql_server.rule=Host(`localhost`) && PathPrefix(`/api/`)
+      - traefik.http.routers.zendro_graphql_server.middlewares=strip-api@docker
+      - traefik.http.middlewares.strip-api.stripprefix.prefixes=/api/
+    extra_hosts:
+      - "localhost:host-gateway"
     command:
       - /bin/sh
       - -c
       - |
+        sed -e '/127.0.0.1\tlocalhost/d' -e 's/^::1\tlocalhost/::1\t/' /etc/hosts > /etc/hosts2 && cp /etc/hosts2 /etc/hosts && rm /etc/hosts2
         npm install
         chmod u+x ./migrateDbAndStartServer.sh
         ./migrateDbAndStartServer.sh
@@ -80,28 +97,31 @@ services:
     build:
       context: ./contexts
       dockerfile: Dockerfile.spa
-    # Using ports in this way is a security concern. Please consider using e.g. a reverseproxy
-    ports:
-      - 8080:8080
     environment:
       # Set your production environment variables here or in ./single-page-app/.env.production
       PORT: "8080"
     volumes:
       - ./single-page-app:/usr/single-page-app
       - ./data_model_definitions:/usr/data_model_definitions
-    # Install dependencies and start single-page-app-server in development
-    # mode.
+    networks:
+      zendro:
+    labels:
+      - traefik.http.routers.zendro_spa.rule=Host(`localhost`) && PathPrefix(`/spa`)
+    # Workaround for local development and Sandbox setups. Can be remove in production deployment
+    extra_hosts:
+      - "localhost:host-gateway"
+    # workaround "sed" command to enable a development / production-Sandbox mode in a local environment
+    # can be removed in a production deployment
     command:
       - /bin/sh
       - -c
       - |
+        sed -e '/127.0.0.1\tlocalhost/d' -e 's/^::1\tlocalhost/::1\t/' /etc/hosts > /etc/hosts2 && cp /etc/hosts2 /etc/hosts && rm /etc/hosts2
         rm -rf .next
         rm -rf out
         yarn install
         yarn build
         yarn start
-    networks:
-      zendro:
 
   zendro_graphiql:
     container_name: zendroStarterPack_graphiql-auth
@@ -112,9 +132,6 @@ services:
     build:
       context: ./contexts
       dockerfile: Dockerfile.graphiql
-    # Using ports in this way is a security concern. Please consider using e.g. a reverseproxy
-    ports:
-      - 7000:7000
     environment:
       # Set your production environment variables here
       PORT: "7000"
@@ -124,10 +141,18 @@ services:
     # mode.
     networks:
       zendro:
+    labels:
+      - traefik.http.routers.zendro_graphiql.rule=Host(`localhost`) && PathPrefix(`/graphiql`)
+    # Workaround for local development and Sandbox setups. Can be remove in production deployment
+    extra_hosts:
+      - "localhost:host-gateway"
+    # workaround "sed" command to enable a development / production-Sandbox mode in a local environment
+    # can be removed in a production deployment
     command:
       - /bin/sh
       - -c
       - |
+        sed -e '/127.0.0.1\tlocalhost/d' -e 's/^::1\tlocalhost/::1\t/' /etc/hosts > /etc/hosts2 && cp /etc/hosts2 /etc/hosts && rm /etc/hosts2
         rm -rf .next
         rm -rf out
         yarn install
@@ -140,8 +165,4 @@ volumes:
 
 networks:
   zendro:
-    driver: bridge
-    ipam:
-      config:
-        - subnet: 10.5.0.0/24
   datastores:


### PR DESCRIPTION
## Summary

This PR implements a revised docker setup for development and production environments, that can be run as well in a local Sandbox.

## Changes
- fix: use correct `.env.development` files in keycloak migration
- refactor the docker setup to use reverse-proxy (traefik) in production and open ports in development
- workaround: edit `/etc/hosts` container file on startup to map localhost to the `host-gateway` ip.

## Related PRs
- spa: https://github.com/Zendro-dev/single-page-app/pull/122
- CLI: https://github.com/Zendro-dev/zendro/pull/6
- graphiql-auth: https://github.com/Zendro-dev/graphiql-auth/pull/20
- graphql-server: https://github.com/Zendro-dev/graphql-server/pull/87